### PR TITLE
feat: Add progress indicator, logging, and download button

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,6 +12,7 @@
     "default_popup": "popup.html",
     "default_icon": {
       "16": "images/icon16.png",
+      "32": "images/icon48.png",
       "48": "images/icon48.png",
       "128": "images/icon128.png"
     }
@@ -28,6 +29,7 @@
   ],
   "icons": {
     "16": "images/icon16.png",
+    "32": "images/icon48.png",
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -10,9 +10,14 @@
 <body>
   <h1>Gerador de Manual</h1>
   <div id="status" style="min-height: 20px; color: green;"></div>
+  <div id="progressContainer" style="display: none;">
+    <progress id="progressBar" value="0" max="100"></progress>
+    <div id="progressText"></div>
+  </div>
   <button id="captureBtn">Capturar esta Página</button>
   <hr>
   <button id="generateBtn">Gerar Manual</button>
+  <button id="downloadBtn" title="Baixar o último manual gerado" style="display: none;">Baixar Manual</button>
   <button id="clearBtn" title="Limpar todos os artigos salvos">Limpar</button>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,7 +1,11 @@
 const captureBtn = document.getElementById('captureBtn');
 const generateBtn = document.getElementById('generateBtn');
 const clearBtn = document.getElementById('clearBtn');
+const downloadBtn = document.getElementById('downloadBtn');
 const statusDiv = document.getElementById('status');
+const progressContainer = document.getElementById('progressContainer');
+const progressBar = document.getElementById('progressBar');
+const progressText = document.getElementById('progressText');
 
 function showStatus(message, isError = false, duration = 0) {
     statusDiv.textContent = message;
@@ -13,6 +17,32 @@ function showStatus(message, isError = false, duration = 0) {
         }, duration);
     }
 }
+
+// Verifica no início se um manual já existe para habilitar o botão de download
+function checkExistingManual() {
+    chrome.storage.local.get('lastGeneratedManualHtml', (result) => {
+        if (result.lastGeneratedManualHtml) {
+            downloadBtn.style.display = 'block';
+        }
+    });
+}
+
+// Listener for messages from the background script
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === "progressUpdate") {
+        const percent = (request.total > 0) ? (request.current / request.total) * 100 : 0;
+        progressBar.value = percent;
+        progressText.textContent = `Etapa ${request.current} de ${request.total}...`;
+    } else if (request.action === "generationComplete") {
+        progressContainer.style.display = 'none';
+        generateBtn.disabled = false;
+        captureBtn.disabled = false;
+        showStatus('Manual gerado com sucesso!', false, 3000);
+        if (request.downloadReady) {
+            downloadBtn.style.display = 'block';
+        }
+    }
+});
 
 captureBtn.addEventListener('click', () => {
     captureBtn.disabled = true;
@@ -35,15 +65,51 @@ captureBtn.addEventListener('click', () => {
 });
 
 generateBtn.addEventListener('click', () => {
-    showStatus('Gerando manual...', false);
+    showStatus('');
+    progressContainer.style.display = 'block';
+    progressText.textContent = 'Iniciando...';
+    progressBar.value = 0;
+    downloadBtn.style.display = 'none';
+
+    generateBtn.disabled = true;
+    captureBtn.disabled = true;
+
     chrome.runtime.sendMessage({ action: "generateManual" });
-    // A popup pode fechar antes do manual ser gerado, o que é aceitável.
-    setTimeout(() => window.close(), 500);
 });
 
 clearBtn.addEventListener('click', () => {
     if (confirm("Tem certeza que deseja limpar todos os artigos salvos?")) {
         chrome.runtime.sendMessage({ action: "clearArticles" });
-        showStatus('Artigos limpos!', false, 1500);
+        // Limpa também o manual salvo para download
+        chrome.storage.local.remove('lastGeneratedManualHtml', () => {
+            downloadBtn.style.display = 'none';
+            showStatus('Artigos e manual limpos!', false, 2000);
+        });
     }
 });
+
+downloadBtn.addEventListener('click', () => {
+    downloadBtn.disabled = true;
+    showStatus('Preparando download...', false);
+
+    chrome.storage.local.get('lastGeneratedManualHtml', (result) => {
+        if (result.lastGeneratedManualHtml) {
+            const blob = new Blob([result.lastGeneratedManualHtml], { type: 'text/html' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'manual.html';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            showStatus('Download iniciado!', false, 2000);
+        } else {
+            showStatus('Nenhum manual encontrado para baixar.', true, 3000);
+        }
+        downloadBtn.disabled = false;
+    });
+});
+
+// Inicializa o estado do botão de download ao abrir o popup
+checkExistingManual();


### PR DESCRIPTION
This commit implements several user-experience and utility improvements to the manual generator extension.

- **Progress Indicator:**
  - The manual generation process now displays a progress bar and a "Step X of Y" message in the popup UI.
  - The popup remains open during generation to show the progress.
  - The generation logic in `background.js` was refactored to be asynchronous and send progress updates to the popup.

- **Activity Logging:**
  - A timestamped logging system has been added to `background.js`.
  - Key application events, such as page captures, generation start/progress/finish, and clearing data, are now logged to `chrome.storage.local` for debugging and tracking purposes.
  - The log is capped at 200 entries to prevent it from growing indefinitely.

- **Download Button:**
  - A "Download Manual" button is now available in the popup.
  - After a manual is generated, the final HTML is saved to local storage.
  - The download button appears if a saved manual is detected and allows the user to download the `manual.html` file directly.